### PR TITLE
Support PHP 8

### DIFF
--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -24,10 +24,10 @@ class StringUtils
     {
         try {
             $cutOff = strpos($value, '.', $offset);
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $cutOff = 0;
         }
-        
+
         return substr($value, 0, $cutOff ?: strlen($value));
     }
 }


### PR DESCRIPTION
When you use PHP 8 _and_ Google Chrome is not installed on the host, you get a pretty cryptic error (well, it's cryptic but not _pretty_ 😄 )
```
PHP Fatal error:  Uncaught ValueError: strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack) in src/Utils/StringUtils.php:26
```

This is because when Google Chrome is not installed, argument 1 (`$value`) is an empty string. In PHP 7, this threw an Exception. In PHP 8, it's an Error, so it wasn't caught.